### PR TITLE
Add Tflite model support for ARM

### DIFF
--- a/neon_stt_plugin_deepspeech_stream_local/__init__.py
+++ b/neon_stt_plugin_deepspeech_stream_local/__init__.py
@@ -29,7 +29,7 @@ import numpy as np
 import time
 import math
 from queue import Queue
-
+from neon_utils.configuration_utils import get_neon_device_type
 from neon_stt_plugin_deepspeech_stream_local.util import get_model
 
 try:
@@ -58,8 +58,10 @@ class DeepSpeechLocalStreamingSTT(StreamingSTT):
         if not self.language.startswith("en"):
             raise ValueError("DeepSpeech is currently english only")
 
+        default_model = "deepspeech-0.9.3-models.tflite" if get_neon_device_type() in ("pi", "neonPi") else \
+            "deepspeech-0.9.3-models.pbmm"
         model_path = self.config.get("model_path") or \
-            os.path.expanduser("~/.local/share/neon/deepspeech-0.9.3-models.pbmm")
+            os.path.expanduser(f"~/.local/share/neon/{default_model}")
         scorer_path = self.config.get("scorer_path") or \
             os.path.expanduser("~/.local/share/neon/deepspeech-0.9.3-models.scorer")
         if not os.path.isfile(model_path):

--- a/neon_stt_plugin_deepspeech_stream_local/__init__.py
+++ b/neon_stt_plugin_deepspeech_stream_local/__init__.py
@@ -67,7 +67,7 @@ class DeepSpeechLocalStreamingSTT(StreamingSTT):
         if not os.path.isfile(model_path):
             LOG.error("Model not found and will be downloaded!")
             LOG.error(model_path)
-            get_model()
+            get_model(tflite=model_path.endswith(".tflite"))
 
         self.client = deepspeech.Model(model_path)
 

--- a/neon_stt_plugin_deepspeech_stream_local/__init__.py
+++ b/neon_stt_plugin_deepspeech_stream_local/__init__.py
@@ -76,6 +76,7 @@ class DeepSpeechLocalStreamingSTT(StreamingSTT):
             LOG.info("download scorer from https://github.com/mozilla/DeepSpeech")
         else:
             self.client.enableExternalScorer(scorer_path)
+        LOG.debug("Deepspeech STT Ready")
 
     def create_streaming_thread(self):
         self.queue = Queue()

--- a/neon_stt_plugin_deepspeech_stream_local/util.py
+++ b/neon_stt_plugin_deepspeech_stream_local/util.py
@@ -24,11 +24,14 @@ import os
 import requests
 
 
-def get_model(ver="0.9.3"):
+def get_model(ver="0.9.3", tflite=False):
     try:
         if not os.path.isdir(os.path.expanduser("~/.local/share/neon/")):
             os.makedirs(os.path.expanduser("~/.local/share/neon/"))
-        model_url = f'https://github.com/mozilla/DeepSpeech/releases/download/v{ver}/deepspeech-{ver}-models.pbmm'
+        if tflite:
+            model_url = f'https://github.com/mozilla/DeepSpeech/releases/download/v{ver}/deepspeech-{ver}-models.tflite'
+        else:
+            model_url = f'https://github.com/mozilla/DeepSpeech/releases/download/v{ver}/deepspeech-{ver}-models.pbmm'
         scorer_url = f'https://github.com/mozilla/DeepSpeech/releases/download/v{ver}/deepspeech-{ver}-models.scorer'
         model_path = os.path.expanduser(f"~/.local/share/neon/deepspeech-{ver}-models.pbmm")
         scorer_path = os.path.expanduser(f"~/.local/share/neon/deepspeech-{ver}-models.scorer")

--- a/neon_stt_plugin_deepspeech_stream_local/util.py
+++ b/neon_stt_plugin_deepspeech_stream_local/util.py
@@ -30,10 +30,11 @@ def get_model(ver="0.9.3", tflite=False):
             os.makedirs(os.path.expanduser("~/.local/share/neon/"))
         if tflite:
             model_url = f'https://github.com/mozilla/DeepSpeech/releases/download/v{ver}/deepspeech-{ver}-models.tflite'
+            model_path = os.path.expanduser(f"~/.local/share/neon/deepspeech-{ver}-models.tflite")
         else:
             model_url = f'https://github.com/mozilla/DeepSpeech/releases/download/v{ver}/deepspeech-{ver}-models.pbmm'
+            model_path = os.path.expanduser(f"~/.local/share/neon/deepspeech-{ver}-models.pbmm")
         scorer_url = f'https://github.com/mozilla/DeepSpeech/releases/download/v{ver}/deepspeech-{ver}-models.scorer'
-        model_path = os.path.expanduser(f"~/.local/share/neon/deepspeech-{ver}-models.pbmm")
         scorer_path = os.path.expanduser(f"~/.local/share/neon/deepspeech-{ver}-models.scorer")
 
         if not os.path.isfile(model_path):

--- a/version.py
+++ b/version.py
@@ -17,4 +17,4 @@
 # US Patents 2008-2021: US7424516, US20140161250, US20140177813, US8638908, US8068604, US8553852, US10530923, US10530924
 # China Patent: CN102017585  -  Europe Patent: EU2156652  -  Patents Pending
 
-__version__ = "0.0.5"
+__version__ = "0.0.6"


### PR DESCRIPTION
ARM64 builds of deepspeech only support tflite. This adds support for platform detection to install and use the appropriate model on Pi devices.