### PR TITLE
Prevent processing empty transcriptions

### DIFF
--- a/neon_stt_plugin_deepspeech_stream_local/__init__.py
+++ b/neon_stt_plugin_deepspeech_stream_local/__init__.py
@@ -132,11 +132,15 @@ class DeepSpeechLocalStreamThread(StreamThread):
             self.transcriptions.append("".join(letters).strip())
         # self.transcriptions = responses
         LOG.debug(self.transcriptions)
-        if has_data:  # Model sometimes returns transcripts for absolute silence
-            LOG.debug(f"Audio had data!!")
+        if not self.transcriptions[0]:
+            LOG.info("First transcription is empty")
+            self.text = None
+            self.transcriptions = []
+        elif has_data:  # Model sometimes returns transcripts for absolute silence
+            LOG.debug("Audio had data")
             self.text = self.transcriptions[0]
         else:
-            LOG.warning(f"Audio was empty!")
+            LOG.warning("Audio was empty")
             self.text = None
             self.transcriptions = []
         if self.results_event:

--- a/version.py
+++ b/version.py
@@ -17,4 +17,4 @@
 # US Patents 2008-2021: US7424516, US20140161250, US20140177813, US8638908, US8068604, US8553852, US10530923, US10530924
 # China Patent: CN102017585  -  Europe Patent: EU2156652  -  Patents Pending
 
-__version__ = "0.0.5"
+__version__ = "0.0.7"


### PR DESCRIPTION
Don't return transcriptions if first result is empty string (regular occurrence with tflite model running on Pi)